### PR TITLE
Add 'date' as requirement

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -44,6 +44,16 @@ while binaries for libxslt and libexslt areprovided in the
 libxslt-ruby bindings.
 
 
+Installation from source:
+
+ruby ext/libxslt/extconf.rb
+make
+sudo make install
+
+gem build xslt-ruby.gemspec
+gem install xslt-ruby-1.1.1.gem
+
+
 == USAGE
 
 For in-depth information about using libxslt-ruby please refer

--- a/README.rdoc
+++ b/README.rdoc
@@ -50,8 +50,8 @@ ruby ext/libxslt/extconf.rb
 make
 sudo make install
 
-gem build xslt-ruby.gemspec
-gem install xslt-ruby-1.1.1.gem
+gem build libxslt-ruby.gemspec
+gem install libxslt-ruby-1.1.1.gem
 
 
 == USAGE

--- a/libxslt-ruby.gemspec
+++ b/libxslt-ruby.gemspec
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'date'
 
 # Determine the current version of the software
 version = File.read('ext/libxslt/version.h').match(/\s*RUBY_LIBXSLT_VERSION\s*['"](\d.+)['"]/)[1]


### PR DESCRIPTION
When running `gem build xslt-ruby.gemspec` I ran into the following problem:

    Invalid gemspec in [libxslt-ruby.gemspec]: uninitialized constant Gem::Specification::DateTime
    Did you mean?  Gem::Specification::DateLike
    ERROR:  Error loading gemspec. Aborting.

Adding `date` as a requirement as suggested here: https://github.com/erplsf/libxslt-ruby/blob/ad0f28b5f1daaa56b1c5a8740421baf37d37ab26/libxslt-ruby.gemspec fixed the issue for me.